### PR TITLE
Add simple logger for Data Expert Chat messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Data_Bot
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Data Bot Logger
+
+This repository contains a simple Python script to log incoming messages.
+
+## Usage
+
+Run the script and type messages. Each message entered will be appended to the file `Data_Bot`.
+
+```bash
+python3 data_bot_logger.py
+```
+
+Type messages and press `Ctrl+D` or `Ctrl+C` to stop.

--- a/data_bot_logger.py
+++ b/data_bot_logger.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import sys
+
+FILE_NAME = 'Data_Bot'
+
+def main():
+    try:
+        for line in sys.stdin:
+            message = line.rstrip('\n')
+            with open(FILE_NAME, 'a', encoding='utf-8') as f:
+                f.write(message + '\n')
+    except KeyboardInterrupt:
+        pass
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `data_bot_logger.py` to save incoming messages to a file
- document usage in `README.md`
- ignore generated `Data_Bot` file

## Testing
- `python3 data_bot_logger.py <<'EOF'
hello
world
EOF`

------
https://chatgpt.com/codex/tasks/task_b_6850caaec3a4832b993e27435ca146fc